### PR TITLE
use Text to create elasticsearch attributes (instead of String)

### DIFF
--- a/src/main/java/io/workshop/CHAPTER1.md
+++ b/src/main/java/io/workshop/CHAPTER1.md
@@ -327,8 +327,8 @@ io.workshop.intro.GetFinalCount
 
 * Add search attributes via tctl:
 ```
-tctl admin cluster add-search-attributes --name CustomerTitle --type String
-tctl admin cluster add-search-attributes --name CustomerLanguages --type String
+tctl admin cluster add-search-attributes --name CustomerTitle --type Text
+tctl admin cluster add-search-attributes --name CustomerLanguages --type Text
 tctl admin cluster add-search-attributes --name CustomerAge --type Int
 ```
 


### PR DESCRIPTION
When I run the command to create elasticsearch attributes, by using the command-line tool, I have the following warning: 

`String type is deprecated, use Text instead`
